### PR TITLE
Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,19 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>spring-aot-maven-plugin</artifactId>
+                <version>${spring.native.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The `spring-aot-maven-plugin` was missing. This is well-documented at the [reference documentation](https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#_add_the_spring_aot_plugin).